### PR TITLE
chore: bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "test": "npm run lint && node test"
   },
   "dependencies": {
-    "highlight.js": "^9.9.0",
-    "lodash.flow": "^3.1.0"
+    "highlight.js": "^9.18.1",
+    "lodash.flow": "^3.5.0"
   },
   "devDependencies": {
-    "markdown-it": "^8.3.0",
-    "standard": "^8.6.0"
+    "markdown-it": "^10.0.0",
+    "standard": "^14.3.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const { equal } = require('assert')
+const { strictEqual: equal } = require('assert')
 const md = require('markdown-it')
 const highlightjs = require('./')
 


### PR DESCRIPTION
bump dependencies;
replace deprecated assert.equal with assert.strictEqual for linter