### PR TITLE
feat: register languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,19 @@ const md = require('markdown-it')()
 
 The `opts` object can contain:
 
-Name   | Description                                                             | Default
--------|-------------------------------------------------------------------------|--------
-`auto` | Whether to automatically detect language if not specified.              | `true`
-`code` | Whether to add the `hljs` class to raw code blocks (not fenced blocks). | `true`
+Name       | Type | Description                                                                | Default
+-----------|------|----------------------------------------------------------------------------|--------
+`auto`     | boolean | Whether to automatically detect language if not specified.              | `true`
+`code`     | boolean | Whether to add the `hljs` class to raw code blocks (not fenced blocks). | `true`
+`register` | object  | Register other languages which are not included in the standard pack.   | null
+
+### Register languages
+
+```js
+const md = require('markdown-it')()
+  .use(require('markdown-it-highlightjs'), {
+    register: {
+      cypher: require('highlightjs-cypher')
+    }
+  })
+```

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ const maybe = f => {
   }
 }
 
+// allow registration of other languages
+const registerLangs = (register) => register &&
+  Object.entries(register).map(([lang, pack]) => { hljs.registerLanguage(lang, pack) })
+
 // Highlight with given language.
 const highlight = (code, lang) =>
   maybe(() => hljs.highlight(lang, code, true).value) || ''
@@ -28,6 +32,7 @@ const wrap = render =>
 
 const highlightjs = (md, opts) => {
   opts = Object.assign({}, highlightjs.defaults, opts)
+  registerLangs(opts.register)
 
   md.options.highlight = opts.auto ? highlightAuto : highlight
   md.renderer.rules.fence = wrap(md.renderer.rules.fence)

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const { equal } = require('assert')
+const { strictEqual: equal } = require('assert')
 const md = require('markdown-it')
 const highlightjs = require('./')
 
@@ -37,3 +37,10 @@ equal(
   `<pre><code class="hljs">&lt;?php echo 42;
 </code></pre>
 `)
+
+equal(
+  md().use(highlightjs, { register: { test: require('highlight.js/lib/languages/sql') } })
+    .render('```test\nSELECT * FROM TABLE;\n```'),
+  '<pre><code class="hljs language-test"><span class="hljs-keyword">SELECT</span> * <span class="hljs-keyword">FROM</span> <span class="hljs-keyword">TABLE</span>;\n' +
+    '</code></pre>\n'
+)


### PR DESCRIPTION
allow registering languages which are not part of highlight.js standard languages.