### PR TITLE
fix: console log Unknown language: ""

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const maybe = f => {
 
 // Highlight with given language.
 const highlight = (code, lang) =>
-  maybe(() => hljs.highlight(lang, code, true).value) || ''
+  maybe(() => hljs.highlight(lang || 'plaintext', code, true).value) || ''
 
 // Highlight with given language or automatically.
 const highlightAuto = (code, lang) =>

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const { equal } = require('assert')
+const { strictEqual: equal } = require('assert')
 const md = require('markdown-it')
 const highlightjs = require('./')
 


### PR DESCRIPTION
highlight.js throws an error for option `{auto: false}` if no language
is given. As an ugly side-effect this error is logged via console.log.
Setting the language in those cases to `plaintext` prevents this.

No new test case required as already being covered. You'll only notice that the console.log error message is gone.