### PR TITLE
Add option to allow inline code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Name       | Type | Description                                                 
 `auto`     | boolean | Whether to automatically detect language if not specified.              | `true`
 `code`     | boolean | Whether to add the `hljs` class to raw code blocks (not fenced blocks). | `true`
 `register` | object  | Register other languages which are not included in the standard pack.   | `null`
-`inline`   | boolean | Highlight inline code blocks                                            | `null`
+`inline`   | boolean | Highlight inline code blocks                                            | `false`
 
 ### Register languages
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Name       | Type | Description                                                 
 `auto`     | boolean | Whether to automatically detect language if not specified.              | `true`
 `code`     | boolean | Whether to add the `hljs` class to raw code blocks (not fenced blocks). | `true`
 `register` | object  | Register other languages which are not included in the standard pack.   | `null`
+`inline`   | boolean | Highlight inline code blocks                                            | `null`
 
 ### Register languages
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Name       | Type | Description                                                 
 `auto`     | boolean | Whether to automatically detect language if not specified.              | `true`
 `code`     | boolean | Whether to add the `hljs` class to raw code blocks (not fenced blocks). | `true`
 `register` | object  | Register other languages which are not included in the standard pack.   | `null`
-`inline`   | boolean | Highlight inline code blocks                                            | `false`
+`inline`   | boolean | Whether to highlight inline code.                                       | `false`
 
 ### Register languages
 
@@ -34,3 +34,26 @@ const md = require('markdown-it')()
     }
   })
 ```
+
+### Inline code highlighting
+
+You can enable inline code highlighting by setting `inline` to true:
+
+```js
+const md = require('markdown-it')()
+  .use(require('markdown-it-highlightjs'), { inline: true })
+```
+
+You can specify the language for inline code using [Pandoc syntax](https://pandoc.org/MANUAL.html#extension-inline_code_attributes):
+
+```markdown
+`x=4`{.js}
+```
+
+or [Kramdown IAL syntax](https://kramdown.gettalong.org/syntax.html#inline-attribute-lists)
+
+```markdown
+`x=4`{:.js}
+```
+
+If you do not specify a language, then highlight.js will attempt to guess the language if `auto` is true (which it is by default).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can specify the language for inline code using [Pandoc syntax](https://pando
 `x=4`{.js}
 ```
 
-or [Kramdown IAL syntax](https://kramdown.gettalong.org/syntax.html#inline-attribute-lists)
+or [Kramdown IAL syntax](https://kramdown.gettalong.org/syntax.html#inline-attribute-lists):
 
 ```markdown
 `x=4`{:.js}

--- a/index.js
+++ b/index.js
@@ -40,6 +40,31 @@ const highlightjs = (md, opts) => {
   if (opts.code) {
     md.renderer.rules.code_block = wrap(md.renderer.rules.code_block)
   }
+
+  if (opts.inline) {
+    // Match kramdown- or pandoc-style language specifier.
+    // e.g. `code`{:.ruby} or `code`{.haskell}
+    const re = new RegExp('^{:?.([^}]+)}')
+
+    md.renderer.rules.code_inline = (tokens, idx) => {
+      const code = tokens[idx]
+      const next = tokens[idx + 1]
+      let lang = ''
+      if (next && next.type === 'text') {
+        const match = re.exec(next.content)
+        if (match) {
+          lang = match[1]
+
+          // Remove the language specification from text following the code.
+          next.content = next.content.slice(match[0].length)
+        }
+      }
+
+      const highlighted = md.options.highlight(code.content, lang)
+      const cls = lang ? ` class="language-${lang}"` : ''
+      return `<code${cls}>${highlighted}</code>`
+    }
+  }
 }
 
 highlightjs.defaults = {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ const highlightjs = (md, opts) => {
   if (opts.inline) {
     // Match kramdown- or pandoc-style language specifier.
     // e.g. `code`{:.ruby} or `code`{.haskell}
-    const re = new RegExp('^{:?.([^}]+)}')
+    const re = new RegExp('^{:?\\.([^}]+)}')
 
     md.renderer.rules.code_inline = (tokens, idx) => {
       const code = tokens[idx]

--- a/test.js
+++ b/test.js
@@ -44,3 +44,27 @@ equal(
   `<pre><code class="hljs language-test"><span class="hljs-keyword">SELECT</span> * <span class="hljs-keyword">FROM</span> <span class="hljs-keyword">TABLE</span>;
 </code></pre>
 `)
+
+// Inline works with pandoc format e.g. `code`{.lang}
+equal(
+  md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`{.js}'),
+  '<code class="language-js"><span class="hljs-built_in">console</span>.log(<span class="hljs-number">42</span>)</code>')
+
+// Inline works with kramdown format e.g. `code`{:.lang}
+equal(
+  md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`{:.js}'),
+  '<code class="language-js"><span class="hljs-built_in">console</span>.log(<span class="hljs-number">42</span>)</code>')
+
+// Inline is not enabled by default
+equal(
+  md().use(highlightjs).renderInline('`console.log(42)`{.js}'),
+  '<code>console.log(42)</code>{.js}')
+
+// Inline uses same auto behaviour as blocks.
+equal(
+  md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`'),
+  '<code>console.<span class="hljs-built_in">log</span>(<span class="hljs-number">42</span>)</code>')
+
+equal(
+  md().use(highlightjs, { inline: true, auto: false }).renderInline('`console.log(42)`'),
+  '<code>console.log(42)</code>')


### PR DESCRIPTION
Add option to allow inline highlighting. Language can be specified using pandoc or kramdown syntax (see readme for links).