### PR TITLE
Bump highlight.js from 9.18.1 to 10.1.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function inlineCodeRenderer (tokens, idx, options) {
   }
 
   const highlighted = options.highlight(code.content, lang)
-  const cls = lang ? ` class="language-${lang}"` : ''
+  const cls = lang ? ` class="${options.langPrefix + lang}"` : ''
 
   return `<code${cls}>${highlighted}</code>`
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "npm run lint && node test"
   },
   "dependencies": {
-    "highlight.js": "^9.18.1",
+    "highlight.js": "^10.1.1",
     "lodash.flow": "^3.5.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -28,8 +28,8 @@ equal(
 
 equal(
   md().use(highlightjs).render('```\n<?php echo 42;\n```'),
-  `<pre><code class="hljs"><span class="php"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-number">42</span>;
-</span></code></pre>
+  `<pre><code class="hljs"><span class="hljs-meta">&lt;?php</span> <span class="hljs-keyword">echo</span> <span class="hljs-number">42</span>;
+</code></pre>
 `)
 
 equal(


### PR DESCRIPTION
Bumps highlight.js from 9.18.1 to 10.1.1

After review of [VERSION_10_UPGRADE.md](https://github.com/highlightjs/highlight.js/blob/master/VERSION_10_UPGRADE.md) and [VERSION_10_BREAKING_CHANGES.md](https://github.com/highlightjs/highlight.js/blob/master/VERSION_10_BREAKING_CHANGES.md), found no incompatibility with markdown-it-highlightjs.

Although one of the tests add to be adjusted since v10 no longer outputs surrounding `<span class='php'>...</span>`