### PR TITLE
fix: escape invalid lang characters (XSS)

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function inlineCodeRenderer (tokens, idx, options) {
   if (next && next.type === 'text') {
     // Match kramdown- or pandoc-style language specifier.
     // e.g. `code`{:.ruby} or `code`{.haskell}
-    const match = /^{:?\.([^}]+)}/.exec(next.content)
+    const match = /^{:?\.([^}"'<>&]+)}/.exec(next.content)
 
     if (match) {
       lang = match[1]

--- a/test.js
+++ b/test.js
@@ -55,6 +55,11 @@ equal(
   md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`{:.js}'),
   '<code class="language-js"><span class="hljs-built_in">console</span>.log(<span class="hljs-number">42</span>)</code>')
 
+// Escape invalid lang characters
+equal(
+  md().use(highlightjs, { inline: true }).renderInline('`console.log(42)`{:."><img onerror=alert(1) src=.>js}'),
+  '<code>console.<span class="hljs-built_in">log</span>(<span class="hljs-number">42</span>)</code>{:.&quot;&gt;&lt;img onerror=alert(1) src=.&gt;js}')
+
 // Inline is not enabled by default
 equal(
   md().use(highlightjs).renderInline('`console.log(42)`{.js}'),


### PR DESCRIPTION
I found XSS in inline code highlighting.

Example

```
`console.log(42)`{."><img onerror=alert(1) src=.>js}
```

Results

```
<p><code class="language-"><img onerror=alert(1) src=.>js"></code></p>
```

Similar problem: https://github.com/jGleitz/markdown-it-prism/pull/137

